### PR TITLE
고침: 차단 취소하면 반영 안되는 이슈 fix

### DIFF
--- a/community/apps/bans/api/serializers/sync.py
+++ b/community/apps/bans/api/serializers/sync.py
@@ -9,4 +9,4 @@ from community.apps.bans.models import UserBan
 class UserBanSyncSerializer(ModelSerializer):
     class Meta:
         model = UserBan
-        fields = ('is_active',)
+        fields = ('is_active', 'is_deleted')

--- a/community/apps/posts/models/managers/active.py
+++ b/community/apps/posts/models/managers/active.py
@@ -36,8 +36,8 @@ class PostActiveManager(PostMainManager):
             )
 
             # 차단되거나 차단한 유저의 글 제외
-            user_bans = UserBan.objects.filter(Q(sender_id=user.id) | Q(receiver_id=user.id)).values_list('sender_id',
-                                                                                                          'receiver_id')
+            user_bans = UserBan.available.filter(Q(sender_id=user.id) | Q(receiver_id=user.id)).values_list('sender_id',
+                                                                                                            'receiver_id')
             conditions_ban = ~Q(user_id__in=[x for x in set(chain.from_iterable(user_bans)) if x != user.id])
 
             return super().get_queryset().filter(


### PR DESCRIPTION
# Summary
<img width="1109" alt="스크린샷 2024-04-16 오후 1 19 50" src="https://github.com/superclubs/post-server/assets/82714785/15dc1f37-f2de-43ed-aa6c-09036d10691c">
- Ban 한 후에 Ban을 취소했을 때, posts 데이터가 변경되지 않음

# 원인
- Ban을 취소하면 is_active=True가 되는데 이 때, Ban데이터 조회시 objects매니저를 적용했기 때문에, 논리 삭제 이슈가 있었음.

